### PR TITLE
Fix the inconsistent output of `witch/1` in exercise 1.5

### DIFF
--- a/chapter-1/exercises.pl
+++ b/chapter-1/exercises.pl
@@ -92,9 +92,9 @@ hasBroom(X) :- quidditchPlayer(X).
 %% How does Prolog respond to the following queries?
 
 %% 1. wizard(ron). -> true
-%% 2. witch(ron). -> false
+%% 2. witch(ron). -> undefined procedure
 %% 3. wizard(hermione). -> false
-%% 4. witch(hermione). -> false
+%% 4. witch(hermione). -> undefined procedure
 %% 5. wizard(harry). -> true
 %% 6. wizard(Y). -> Y = ron ; Y = harry.
 %% 7.witch(Y). -> undefined procedure


### PR DESCRIPTION
This fixes the following inconsistency in the solution to **exercise 1.5**:

```
...
2. witch(ron). -> false
...
4. witch(hermione). -> false
...
7.witch(Y). -> undefined procedure
```

I've picked `undefined procedure` as the correct output. Could change it to `false` if you prefer, but I guess it doesn't matter since it is implementation dependent.