### PR TITLE
Fix a typo in the solution to exercise 2.2

### DIFF
--- a/chapter-2/exercises.pl
+++ b/chapter-2/exercises.pl
@@ -46,7 +46,7 @@ magic(X) :- witch(X).
 %% 5. ?- magic(Hermione). ->
 %%    Hermione = dobby;
 %%    Hermione = hermione;
-%%    Hermione = %% 'McGonagall';
+%%    Hermione = 'McGonagall';
 %%    Hermione = rita_skeeter.
 
 %% Draw the search tree for the fifth query magic(Hermione).


### PR DESCRIPTION
Removes mispositioned `%%` in the middle of a line.