### PR TITLE
Fix exercise 4.4 - the tails of the two lists should be identical

### DIFF
--- a/chapter-4/exercises.pl
+++ b/chapter-4/exercises.pl
@@ -33,7 +33,7 @@ second(X,List) :- List = [_,X|_].
 %%4.4 Write a predicate swap12(List1,List2) which checks whether List1 is identical to List2 ,
 %%except that the first two elements are exchanged.
 
-swap12(L1,L2) :- L1 = [L1a,L1b|_], L2 = [L1b,L1a|_]. 
+swap12(L1,L2) :- L1 = [L1a,L1b|T], L2 = [L1b,L1a|T].
 
 %% Exercise 4.5
 %% Suppose we are given a knowledge base with the following facts:


### PR DESCRIPTION
The two bindings of the `_` variable are independent, which means that
they could be bound to different objects. For example:

```prolog
swap12([1, 2, 3], [2, 1, 4]).
```

would evaluate to `true` with the use of `_`. The first `_` gets bound
to `3`, while the second `_` gets bound to `4`.