### PR TITLE
Fix the response to the penultimate query in exercise 9.1

### DIFF
--- a/chapter-9/exercises.pl
+++ b/chapter-9/exercises.pl
@@ -16,7 +16,7 @@
 %% ?- 7-2 =\= 9-2 -> true
 %% ?- p == 'p' -> true
 %% ?- p =\= 'p' -> error
-%% ?- vincent == VAR -> VAR = vincent.
+%% ?- vincent == VAR -> false.
 %% ?- vincent=VAR,VAR==vincent -> VAR = vincent.
 
 %% Exercise 9.2


### PR DESCRIPTION
`==/2` checks if the two arguments are identical terms, it is not the
`=/2` which does unification.