### PR TITLE
Fix the solution to exercise 9.4 to work with nested terms

### DIFF
--- a/chapter-9/exercises.pl
+++ b/chapter-9/exercises.pl
@@ -95,16 +95,16 @@ termtype(Term,term) :-
 %% ?- groundterm(french(whopper,X)).
 %% no
 
-%% convert complex term to list and run through list and check if each element
-%% is nonvar.
+%% convert complex term to list of its arguments and run through list and check
+%% if each element is also a groundterm.
 
 groundterm(Term) :-
   nonvar(Term),
-  Term =.. X,
+  Term =.. [_ | X],
   groundterm_in_list(X).
 
 groundterm_in_list([H|T]) :-
-  nonvar(H),
+  groundterm(H),
   groundterm_in_list(T).
 
 groundterm_in_list([]).


### PR DESCRIPTION
The previous solution was producing wrong answer to the following query:

```prolog
?- groundterm(foo(bar(_))).
true.
```

It is important to note that `groundterm_in_list` should be called in
`groundterm` with a list that does not consist the functor, otherwise
we would end up in an infinite loop. For example:

```prolog
?- groundterm(1).
Out of stack error
```