### PR TITLE
Fix a typo in the practical session of chapter 10

### DIFF
--- a/chapter-10/practical-session.pl
+++ b/chapter-10/practical-session.pl
@@ -69,9 +69,9 @@ max(X,Y,X).
 %% X = 3.
 
 %% max3 has been simplified too much, i.e. the query below is wrong.
-%% [trace]  ?- max(2,1,2).
-%%    Call: (7) max(2, 1, 2) ?
-%%    Exit: (7) max(2, 1, 2) ?
+%% [trace]  ?- max(1,2,1).
+%%    Call: (7) max(1, 2, 1) ?
+%%    Exit: (7) max(1, 2, 1) ?
 %% true.
 
 %% Ok, time for a burger. Try out all the methods discussed in the text for


### PR DESCRIPTION
The given query produces a correct solution. The `1` and `2` should be
swapped to reveal the bug.