### PR TITLE
Fix exercise 11.3 solution to comply with the problem requirements

### DIFF
--- a/chapter-11/exercises.pl
+++ b/chapter-11/exercises.pl
@@ -98,13 +98,19 @@ q(flab,blob).
 %% sigmares(3,6).
 
 %% base case
-mySigma(0, Sum, Sum).
+mySigma(0, Sum, Sum) :-
+    !.
+
+mySigma(N, Acc, Sum) :-
+    sigmares(N, NewSum),
+    Sum is Acc + NewSum,
+    !.
 
 %% inductive case
 mySigma(N, Acc, Sum) :-
-  is(DecN, -(N, 1)), !,
-  is(NewAcc, +(Acc, N)), !,
-  mySigma(DecN, NewAcc, Sum), !.
+  is(DecN, -(N, 1)),
+  is(NewAcc, +(Acc, N)),
+  mySigma(DecN, NewAcc, Sum).
 
 %% main
 :- dynamic sigmares/2.


### PR DESCRIPTION
It didn't comply with the following part of the problem:
> Prolog should not calculate everything new, but shoud get the result
> for `sigma(2, 3)` from the database and only add 3 to that.
Now `mySigma` also makes use of the cached values.

The cuts after the `is` goals were unnecessary since those goals have
only one solution.

Moved the cut that is at the end of the `mySigma` inductive clause to
the first base clause to match the mandatory cut in the second base
clause.