### PR TITLE
Fix entry repetition in exercise 12.2

### DIFF
--- a/chapter-12/exercises.pl
+++ b/chapter-12/exercises.pl
@@ -29,6 +29,7 @@ writeHouses :-
 
 addWordToDatabase(W) :-
   word(W, X),
+  retract(word(W, X)),
   Y is X + 1,
   assert( word(W, Y) ), !.
 
@@ -80,10 +81,6 @@ checkCharAndReadRest(Char, [Char | Chars] , InStream) :-
 %% false.
 
 %% partial output from ?- listing.
-word(foo, 1).
-word(bar, 1).
-word(baz, 1).
-word(bozz, 1).
 word(newline, 1).
 word(bozz, 2).
 word(bar, 2).


### PR DESCRIPTION
Every time we encounter a word that is already in the database we have
to delete its old entry and create a new one.