### PR TITLE
Fix `X` to anonymous variable in `greater_than`

### DIFF
--- a/chapter-03/exercises.pl
+++ b/chapter-03/exercises.pl
@@ -28,7 +28,7 @@ in(X,Y) :-
 %% ?- greater_than(succ(succ(succ(0))),succ(0)). -> true
 %% ?- greater_than(succ(succ(0)),succ(succ(succ(0)))). -> no
 
-greater_than(succ(X),0).
+greater_than(succ(_),0).
 greater_than(succ(X),succ(Y)) :-
   greater_than(X,Y).
 


### PR DESCRIPTION
## WHAT
`greater_than(succ(X),0).` to `greater_than(succ(_),0).`

## WHY
The warning: "Singleton variables: [X]" has been issued.