### PR TITLE
Adding an append_swapfl/2 using append/3

### DIFF
--- a/chapter-06/exercises.pl
+++ b/chapter-06/exercises.pl
@@ -90,6 +90,10 @@ toptail2([_|Tail], OutList):- reverse(Tail, [_|TailReversedRest]), reverse(TailR
 %% identical to List2, except that the first and last elements are
 %% exchanged. Hint: here's where append comes in useful again.
 
+append_swapfl(InList,OutList) :-
+    append([F|Mid],[L], InList),
+    append([L|Mid],[F], OutList).
+    
 swapfl([], []).
 swapfl([First1|Tail1], [First2|Tail2]):-
 	reverse(Tail1, [Last1|Rest1]),


### PR DESCRIPTION
In chapter 6 it is possible to create a swapfl/2 using only the append/3 rule.